### PR TITLE
Bugfix: Wrong usage of portOutputRegister instead of portInputRegister for the _rxPort

### DIFF
--- a/SoftwareUart.h
+++ b/SoftwareUart.h
@@ -350,7 +350,7 @@ SoftwareUart::SoftwareUart(uint8_t receivePin, uint8_t transmitPin, bool inverse
 
 	_rxPin = receivePin;
 	_rxBitMask = digitalPinToBitMask(receivePin);
-	_rxPort = portOutputRegister(digitalPinToPort(receivePin));
+	_rxPort = portInputRegister(digitalPinToPort(receivePin));
 
 	pinMode(_rxPin, INPUT);
 	if (!_inverse_logic) { digitalWrite(_rxPin, HIGH); } // pullup for normal logic


### PR DESCRIPTION
There is a typo when setting _rxPort portOutputRegister() is used instead of portInputRegister(). This breaks receiving data over the soft serial completely. This PR fixes this small mistake.